### PR TITLE
Newfeature/issue 11 return images in events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,21 +36,23 @@ function run() {
 
   Promise.all([eventsData, groupsData])
     .then(function (results) {
-      results[0] = JSON.parse(formatResults(results[0]));
+      let events = JSON.parse(formatResults(results[0]));
+      let groups = results[1];
+      let groupImages = {};
 
-      results[0].map(event => {
-        event.group.group_photo = "TEST";
+      // Build object containing group name, and associated group image.
+      groups.map(group => {
+        groupImages[group.urlname] = group.group_photo !== undefined ? group.group_photo.highres_link : null;
       });
 
-      results[1].map(group => {
-        console.log(`GROUP: ${ group.name } -> ${ group.group_photo !== undefined ? group.group_photo.highres_link : null }`);
+      // Append this image to event
+      events.map(event => {
+        event.group.group_photo = groupImages[event.group.urlname]; // eslint-disable-line camelcase
       });
 
-      resolveMeetupEventsDataLocal(results[0]);
+      resolveAllPromises(events);
     })
     .catch(handleError);
-
-  // resolveAllPromises(eventsData);
 }
 
 function resolveMeetupEventsDataLocal(results) {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love PRs and appreciate any help you can offer!

Please make sure the following criteria are met before submitting your pull request.

1. <strong>PR meets the Contributing Guidelines (see above)</strong>
2. Ensure the test suite passes
3. Make sure your code lints
-->

## Related Issue
<!-- Include a link to the issue (e.g. #12) -->
https://github.com/ProvidenceGeeks/website-lambda-meetup/issues/11

## Summary of Changes
<!-- Briefly summarize the changes made, lists are also appreciated.  Referencing the related issue as a
"TO DO" checklist is also helpful for reviewers

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->
The events API will now pull an image for each group, which has been appended to the group object for each event with the property name "group_photo".

***Note***: I had eslint ignore that one line because it required camel case, but I wanted to keep the properties from the API consistent.
